### PR TITLE
Leverage the ORM selectivity to reduce the amount of data fetched from the RDBMS

### DIFF
--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -242,8 +242,7 @@ class DBTaskRunner(object):
 
     def get_task_to_run(self, tasks, queue=None):
         try:
-            available_tasks = [task for task in Task.objects.find_available(queue)
-                               if task.task_name in tasks._tasks][:5]
+            available_tasks = Task.objects.find_available(queue).filter(task_name__in=tasks._tasks)[:5]
             for task in available_tasks:
                 # try to lock task
                 locked_task = task.lock(self.worker_name)


### PR DESCRIPTION
Since we only need a subset of the tasks from the database, try to leverage the ORM to filter the records on the database to avoid having to send all the unrelated tasks back from the database. This used to be an extremely expensive operation when you have a large number of tasks in the database.

[Original](https://github.com/django-background-tasks/django-background-tasks/pull/244)