### PR TITLE
Leverage the ORM selectivity to reduce the amount of data fetched from the RDBMS

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -53,16 +53,6 @@ class TaskManager(models.Manager):
         _priority_ordering = '{}priority'.format(
             app_settings.BACKGROUND_TASK_PRIORITY_ORDERING)
         ready = ready.order_by(_priority_ordering, 'run_at')
-
-        if app_settings.BACKGROUND_TASK_RUN_ASYNC:
-            currently_failed = self.failed().count()
-            currently_locked = self.locked(now).count()
-            count = app_settings.BACKGROUND_TASK_ASYNC_THREADS - \
-                (currently_locked - currently_failed)
-            if count > 0:
-                ready = ready[:count]
-            else:
-                ready = self.none()
         return ready
 
     def unlocked(self, now):
@@ -81,11 +71,26 @@ class TaskManager(models.Manager):
 
     def failed(self):
         """
-        `currently_locked - currently_failed` in `find_available` assues that
-        tasks marked as failed are also in processing by the running PID.
+        `currently_locked - currently_failed` in `limit_available` assumes
+        that tasks marked as failed are also in processing by the running PID.
         """
         qs = self.get_queryset()
         return qs.filter(failed_at__isnull=False)
+ 
+    def limit_available(self, available, limit=None):
+        if not app_settings.BACKGROUND_TASK_RUN_ASYNC:
+            if limit is not None:
+                return available[:limit]
+            return available
+        now = timezone.now()
+        currently_failed = self.failed().count()
+        currently_locked = self.locked(now).count()
+        count = app_settings.BACKGROUND_TASK_ASYNC_THREADS - \
+            (currently_locked - currently_failed)
+        if count > 0:
+            return available[:count]
+        else:
+            return self.none()
 
     def new_task(self, task_name, args=None, kwargs=None,
                  run_at=None, priority=0, queue=None, verbose_name=None,

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -44,7 +44,7 @@ class TaskManager(models.Manager):
     def created_by(self, creator):
         return self.get_queryset().created_by(creator)
 
-    def find_available(self, queue=None):
+    def find_available(self, queue=None, limit=None):
         now = timezone.now()
         qs = self.unlocked(now)
         if queue:
@@ -53,7 +53,7 @@ class TaskManager(models.Manager):
         _priority_ordering = '{}priority'.format(
             app_settings.BACKGROUND_TASK_PRIORITY_ORDERING)
         ready = ready.order_by(_priority_ordering, 'run_at')
-        return ready
+        return self.limit_available(ready, limit)
 
     def unlocked(self, now):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -53,7 +53,9 @@ class TaskManager(models.Manager):
         _priority_ordering = '{}priority'.format(
             app_settings.BACKGROUND_TASK_PRIORITY_ORDERING)
         ready = ready.order_by(_priority_ordering, 'run_at')
-        return self.limit_available(ready, limit)
+        if limit is not None:
+            return self.limit_available(ready, limit)
+        return ready
 
     def unlocked(self, now):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -242,8 +242,7 @@ class DBTaskRunner(object):
 
     def get_task_to_run(self, tasks, queue=None):
         try:
-            available_tasks = [task for task in Task.objects.find_available(queue)
-                               if task.task_name in tasks._tasks][:5]
+            available_tasks = Task.objects.find_available(queue).filter(task_name__in=tasks._tasks)[:5]
             for task in available_tasks:
                 # try to lock task
                 locked_task = task.lock(self.worker_name)

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -247,7 +247,7 @@ class DBTaskRunner(object):
             ).filter(
                 task_name__in=tasks._tasks
             )
-            for task in Task.objects.limit_available(available_tasks, 5):
+            for task in Task.objects.limit_available(available_tasks, 15):
                 # try to lock task
                 locked_task = task.lock(self.worker_name)
                 if locked_task:

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -242,10 +242,12 @@ class DBTaskRunner(object):
 
     def get_task_to_run(self, tasks, queue=None):
         try:
-            available_tasks = Task.objects.find_available(queue)
-            if not app_settings.BACKGROUND_TASK_RUN_ASYNC:
-                available_tasks = available_tasks.filter(task_name__in=tasks._tasks)[:5]
-            for task in available_tasks:
+            available_tasks = Task.objects.find_available(
+                queue
+            ).filter(
+                task_name__in=tasks._tasks
+            )
+            for task in Task.objects.limit_available(available_tasks, 5):
                 # try to lock task
                 locked_task = task.lock(self.worker_name)
                 if locked_task:

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -242,7 +242,9 @@ class DBTaskRunner(object):
 
     def get_task_to_run(self, tasks, queue=None):
         try:
-            available_tasks = Task.objects.find_available(queue).filter(task_name__in=tasks._tasks)[:5]
+            available_tasks = Task.objects.find_available(queue)
+            if not app_settings.BACKGROUND_TASK_RUN_ASYNC:
+                available_tasks = available_tasks.filter(task_name__in=tasks._tasks)[:5]
             for task in available_tasks:
                 # try to lock task
                 locked_task = task.lock(self.worker_name)


### PR DESCRIPTION
Since we only need a subset of the tasks from the database, try to leverage the ORM to filter the records on the database to avoid having to send all the unrelated tasks back from the database. This used to be an extremely expensive operation when you have a large number of tasks in the database.

[Original](https://github.com/django-background-tasks/django-background-tasks/pull/244)