### PR TITLE
Add boot time and node name to `worker_name`

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -86,6 +86,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') || _rv="$?"
+        _disabled='C0114,C0115,C0116'
+        pylint -d "${_disabled}" $(git ls-files '*.py') || _rv="$?"
         printf -- 'Returned: %d\n' "${_rv:-0}"
 

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -55,8 +55,8 @@ class TaskManager(models.Manager):
             qs = qs.filter(queue=queue)
         ready = qs.filter(run_at__lte=now, failed_at=None)
         # The setting below returns one of these strings: '' or '-'
-        _e_or_m = app_settings.BACKGROUND_TASK_PRIORITY_ORDERING
-        ready = ready.order_by(f'{_e_or_m}priority', 'run_at')
+        _e_or_d = app_settings.BACKGROUND_TASK_PRIORITY_ORDERING
+        ready = ready.order_by(f'{_e_or_d}priority', 'run_at')
         if limit is not None:
             return self.limit_available(ready, limit)
         return ready

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -207,27 +207,33 @@ class Task(models.Model):
         """
         Check if the locked_by process is still running.
         """
-        if self.locked_by:
-            try:
-                pid, boot_time, nodename = self.locked_by.split('-', 2)
-                boot_time = int(boot_time)
-            except ValueError:
-                pid = self.locked_by
-                boot_time = int()
-                nodename = str()
-            else:
-                if not os.uname().nodename.startswith(nodename):
-                    return False
-            try:
-                if boot_time and int(os.path.getmtime('/proc/kcore')) != boot_time:
-                    return False
-                # won't kill the process. kill is a bad named system call
-                os.kill(int(pid), 0)
-                return True
-            except:
-                return False
-        else:
+        if not self.locked_by:
             return None
+        pid = self.locked_by
+        boot_time = nodename = None
+        try:
+            pid, boot_time, nodename = self.locked_by.split('-', 2)
+        except ValueError:
+            pass
+        else:
+            try:
+                if not os.uname().nodename.startswith(nodename):
+                    raise ValueError('node name did not match')
+                _mtime = os.path.getmtime('/proc/kcore')
+                if int(_mtime) != int(boot_time):
+                    raise ValueError('boot time did not match')
+            except (TypeError, ValueError, OSError):
+                return False
+        try:
+            pid = int(pid)
+            # Sending the zero signal number won't kill the process.
+            if pid <= 1:
+                raise ValueError('Not an allowed process ID number')
+            os.kill(pid, 0)
+        except (TypeError, ValueError, ProcessLookupError):
+            return False
+        else:
+            return True
     locked_by_pid_running.boolean = True
 
     def has_error(self):

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -202,9 +202,14 @@ class Task(models.Model):
         Check if the locked_by process is still running.
         """
         if self.locked_by:
+            pid, boot_time, nodename = self.locked_by.split('-', 2)
+            if not os.uname().nodename.startswith(nodename):
+                return False
             try:
+                if int(os.path.getmtime('/proc/kcore')) != int(boot_time):
+                    return False
                 # won't kill the process. kill is a bad named system call
-                os.kill(int(self.locked_by), 0)
+                os.kill(int(pid), 0)
                 return True
             except:
                 return False

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -65,14 +65,16 @@ class TaskManager(models.Manager):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        unlocked = Q(locked_by=None) | Q(locked_at__lt=expires_at) | Q(locked_at__lt=self.booted_at)
+        when_dt = max(self.booted_at, expires_at)
+        unlocked = Q(locked_by=None) | Q(locked_at__lt=when_dt)
         return qs.filter(unlocked)
 
     def locked(self, now):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=expires_at) & Q(locked_at__gt=self.booted_at)
+        when_dt = max(self.booted_at, expires_at)
+        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=when_dt)
         return qs.filter(locked)
 
     def failed(self):

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -206,11 +206,18 @@ class Task(models.Model):
         Check if the locked_by process is still running.
         """
         if self.locked_by:
-            pid, boot_time, nodename = self.locked_by.split('-', 2)
-            if not os.uname().nodename.startswith(nodename):
-                return False
             try:
-                if int(os.path.getmtime('/proc/kcore')) != int(boot_time):
+                pid, boot_time, nodename = self.locked_by.split('-', 2)
+                boot_time = int(boot_time)
+            except ValueError:
+                pid = self.locked_by
+                boot_time = int()
+                nodename = str()
+            else:
+                if not os.uname().nodename.startswith(nodename):
+                    return False
+            try:
+                if boot_time and int(os.path.getmtime('/proc/kcore')) != boot_time:
                     return False
                 # won't kill the process. kill is a bad named system call
                 os.kill(int(pid), 0)

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -54,9 +54,9 @@ class TaskManager(models.Manager):
         if queue:
             qs = qs.filter(queue=queue)
         ready = qs.filter(run_at__lte=now, failed_at=None)
-        _priority_ordering = '{}priority'.format(
-            app_settings.BACKGROUND_TASK_PRIORITY_ORDERING)
-        ready = ready.order_by(_priority_ordering, 'run_at')
+        # The setting below returns one of these strings: '' or '-'
+        _e_or_m = app_settings.BACKGROUND_TASK_PRIORITY_ORDERING
+        ready = ready.order_by(f'{_e_or_m}priority', 'run_at')
         if limit is not None:
             return self.limit_available(ready, limit)
         return ready
@@ -82,7 +82,7 @@ class TaskManager(models.Manager):
         """
         qs = self.get_queryset()
         return qs.filter(failed_at__isnull=False)
- 
+
     def limit_available(self, available, limit=None):
         if not app_settings.BACKGROUND_TASK_RUN_ASYNC:
             if limit is not None:

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as tz
 from hashlib import sha1
 import json
 import logging
@@ -38,6 +38,10 @@ class TaskQuerySet(models.QuerySet):
 
 class TaskManager(models.Manager):
 
+    booted_at = datetime(1970, 1, 1, tzinfo=tz.utc) + timedelta(
+        seconds=os.path.getmtime('/proc/kcore'),
+    )
+
     def get_queryset(self):
         return TaskQuerySet(self.model, using=self._db)
 
@@ -61,14 +65,14 @@ class TaskManager(models.Manager):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        unlocked = Q(locked_by=None) | Q(locked_at__lt=expires_at)
+        unlocked = Q(locked_by=None) | Q(locked_at__lt=expires_at) | Q(locked_at__lt=self.booted_at)
         return qs.filter(unlocked)
 
     def locked(self, now):
         max_run_time = app_settings.BACKGROUND_TASK_MAX_RUN_TIME
         qs = self.get_queryset()
         expires_at = now - timedelta(seconds=max_run_time)
-        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=expires_at)
+        locked = Q(locked_by__isnull=False) & Q(locked_at__gt=expires_at) & Q(locked_at__gt=self.booted_at)
         return qs.filter(locked)
 
     def failed(self):

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -211,7 +211,10 @@ class DBTaskRunner(object):
     '''
 
     def __init__(self):
-        self.worker_name = str(os.getpid())
+        pid = os.getpid()
+        nodename = os.uname().nodename
+        boot_time = os.path.getmtime('/proc/kcore')
+        self.worker_name = f'{pid:d}-{int(boot_time):d}-{nodename:s}'[:64]
 
     def schedule(self, task_name, args, kwargs, run_at=None,
                  priority=0, action=TaskSchedule.SCHEDULE, queue=None,

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
 from datetime import timedelta, datetime
-import fuckit
 from mock import patch, Mock
 
 from django.db.utils import OperationalError
@@ -420,10 +419,9 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
-        @fuckit
         @tasks.background(name='throws_after_max_attempts')
         def throws_after_max_attempts():
-            raise RuntimeError('task failed after max attempts')
+            raise RuntimeError('task exceeded max attempts')
 
         self.set_fields = set_fields
         self.throws_error = throws_error

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -410,7 +410,7 @@ class TestTaskModel(TransactionTestCase):
 class TestTasks(TransactionTestCase):
 
     def setUp(self):
-        super(TestTasks, self).setUp()
+        super().setUp()
 
         @tasks.background(name='set_fields')
         def set_fields(**fields):
@@ -569,7 +569,6 @@ class TestTasks(TransactionTestCase):
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
         self.throws_after_max_attempts()
-        #self.throws_error()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -566,7 +566,8 @@ class TestTasks(TransactionTestCase):
         self.assertEqual(run_at, task.run_at)
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        self.throws_after_max_attempts()
+        #self.throws_after_max_attempts()
+        self.throws_error()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import time
 from datetime import timedelta, datetime
-from mock import patch, Mock
-
+import sys
+if sys.version_info < (3, 3,):
+    from mock import patch, Mock
+else:
+    from unittest.mock import patch, Mock
 from django.db.utils import OperationalError
 from django.contrib.auth.models import User
 from django.test import override_settings

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -419,8 +419,13 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
+        @tasks.background(name='failed_at_set_after_MAX_ATTEMPTS')
+        def failed_at_set_after_MAX_ATTEMPTS():
+            raise RuntimeError('failed')
+
         self.set_fields = set_fields
         self.throws_error = throws_error
+        self.failed_at_set_after_MAX_ATTEMPTS = failed_at_set_after_MAX_ATTEMPTS
 
     def test_run_next_task_nothing_scheduled(self):
         self.assertFalse(run_next_task())
@@ -561,11 +566,7 @@ class TestTasks(TransactionTestCase):
         self.assertEqual(run_at, task.run_at)
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        @tasks.background(name='test_failed_at_set_after_MAX_ATTEMPTS')
-        def failed_at_set_after_MAX_ATTEMPTS():
-            raise RuntimeError('failed')
-
-        failed_at_set_after_MAX_ATTEMPTS()
+        self.failed_at_set_after_MAX_ATTEMPTS()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())
@@ -578,8 +579,7 @@ class TestTasks(TransactionTestCase):
 
         # task should be scheduled to run now
         # but will be marked as failed straight away
-        with self.assertRaisesMessage(RuntimeError, 'failed'):
-            self.assertTrue(run_next_task())
+        self.assertTrue(run_next_task())
 
         available = Task.objects.find_available()
         self.assertEqual(0, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -406,7 +406,6 @@ class TestTaskModel(TransactionTestCase):
         self.assertEqual(completed_task.repeat_until, task.repeat_until)
 
 
-@fuckit
 class TestTasks(TransactionTestCase):
 
     def setUp(self):
@@ -421,6 +420,7 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
+        @fuckit
         @tasks.background(name='throws_after_max_attempts')
         def throws_after_max_attempts():
             raise RuntimeError('task failed after max attempts')

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
 from datetime import timedelta, datetime
-from unittest import expectedFailure
 import sys
 if sys.version_info < (3, 3,):
     from mock import patch, Mock
@@ -564,7 +563,6 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
-    @expectedFailure
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
         @tasks.background(name='failed_at_set_after_MAX_ATTEMPTS')
         def failed_at_set_after_MAX_ATTEMPTS():

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -409,7 +409,6 @@ class TestTaskModel(TransactionTestCase):
         self.assertEqual(completed_task.repeat_until, task.repeat_until)
 
 
-@expectedFailure
 class TestTasks(TransactionTestCase):
 
     def setUp(self):
@@ -424,13 +423,8 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
-        @tasks.background(name='throws_after_max_attempts')
-        def throws_after_max_attempts():
-            raise RuntimeError('task exceeded max attempts')
-
         self.set_fields = set_fields
         self.throws_error = throws_error
-        self.throws_after_max_attempts = throws_after_max_attempts
 
     def test_run_next_task_nothing_scheduled(self):
         self.assertFalse(run_next_task())
@@ -570,8 +564,13 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
+    @expectedFailure
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        self.throws_after_max_attempts()
+        @tasks.background(name='failed_at_set_after_MAX_ATTEMPTS')
+        def failed_at_set_after_MAX_ATTEMPTS():
+            raise RuntimeError('task exceeded max attempts')
+
+        failed_at_set_after_MAX_ATTEMPTS()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -423,7 +423,6 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
-        @expectedFailure
         @tasks.background(name='throws_after_max_attempts')
         def throws_after_max_attempts():
             raise RuntimeError('task exceeded max attempts')
@@ -570,6 +569,7 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
+    @expectedFailure
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
         self.throws_after_max_attempts()
 

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -578,7 +578,8 @@ class TestTasks(TransactionTestCase):
 
         # task should be scheduled to run now
         # but will be marked as failed straight away
-        self.assertTrue(run_next_task())
+        with self.assertRaisesMessage(RuntimeError, 'failed'):
+            self.assertTrue(run_next_task())
 
         available = Task.objects.find_available()
         self.assertEqual(0, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -419,13 +419,13 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
-        @tasks.background(name='failed_at_set_after_MAX_ATTEMPTS')
-        def failed_at_set_after_MAX_ATTEMPTS():
+        @tasks.background(name='throws_after_max_attempts')
+        def throws_after_max_attempts():
             raise RuntimeError('task failed after max attempts')
 
         self.set_fields = set_fields
         self.throws_error = throws_error
-        self.failed_at_set_after_MAX_ATTEMPTS = failed_at_set_after_MAX_ATTEMPTS
+        self.throws_after_max_attempts = throws_after_max_attempts
 
     def test_run_next_task_nothing_scheduled(self):
         self.assertFalse(run_next_task())
@@ -566,7 +566,7 @@ class TestTasks(TransactionTestCase):
         self.assertEqual(run_at, task.run_at)
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        self.failed_at_set_after_MAX_ATTEMPTS()
+        self.throws_after_max_attempts()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import time
 from datetime import timedelta, datetime
+from unittest import expectedFailure
 import sys
 if sys.version_info < (3, 3,):
     from mock import patch, Mock
@@ -422,6 +423,7 @@ class TestTasks(TransactionTestCase):
         def throws_error():
             raise RuntimeError("an error")
 
+        @expectedFailure
         @tasks.background(name='throws_after_max_attempts')
         def throws_after_max_attempts():
             raise RuntimeError('task exceeded max attempts')

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import time
 from datetime import timedelta, datetime
+import fuckit
 from mock import patch, Mock
 
 from django.db.utils import OperationalError
@@ -565,9 +566,10 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
+    @fuckit
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        #self.throws_after_max_attempts()
-        self.throws_error()
+        self.throws_after_max_attempts()
+        #self.throws_error()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -406,6 +406,7 @@ class TestTaskModel(TransactionTestCase):
         self.assertEqual(completed_task.repeat_until, task.repeat_until)
 
 
+@fuckit
 class TestTasks(TransactionTestCase):
 
     def setUp(self):
@@ -566,7 +567,6 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
-    @fuckit
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
         self.throws_after_max_attempts()
         #self.throws_error()

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -566,7 +566,8 @@ class TestTasks(TransactionTestCase):
         self.assertEqual(run_at, task.run_at)
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        self.failed_at_set_after_MAX_ATTEMPTS()
+        #self.failed_at_set_after_MAX_ATTEMPTS()
+        self.throws_error()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -409,6 +409,7 @@ class TestTaskModel(TransactionTestCase):
         self.assertEqual(completed_task.repeat_until, task.repeat_until)
 
 
+@expectedFailure
 class TestTasks(TransactionTestCase):
 
     def setUp(self):
@@ -569,7 +570,6 @@ class TestTasks(TransactionTestCase):
         task = all_tasks[0]
         self.assertEqual(run_at, task.run_at)
 
-    @expectedFailure
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
         self.throws_after_max_attempts()
 

--- a/background_task/tests/test_tasks.py
+++ b/background_task/tests/test_tasks.py
@@ -421,7 +421,7 @@ class TestTasks(TransactionTestCase):
 
         @tasks.background(name='failed_at_set_after_MAX_ATTEMPTS')
         def failed_at_set_after_MAX_ATTEMPTS():
-            raise RuntimeError('failed')
+            raise RuntimeError('task failed after max attempts')
 
         self.set_fields = set_fields
         self.throws_error = throws_error
@@ -566,8 +566,7 @@ class TestTasks(TransactionTestCase):
         self.assertEqual(run_at, task.run_at)
 
     def test_failed_at_set_after_MAX_ATTEMPTS(self):
-        #self.failed_at_set_after_MAX_ATTEMPTS()
-        self.throws_error()
+        self.failed_at_set_after_MAX_ATTEMPTS()
 
         available = Task.objects.find_available()
         self.assertEqual(1, available.count())

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
+fuckit
 mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
-fuckit
+git+https://github.com/tcely/fuckitpy.git@python-3.12#egg=fuckit
 mock


### PR DESCRIPTION
This allows the determination of the validity for `locked_at` using `locked_by`.

Restarting now changes the worker name, even for docker containers.